### PR TITLE
CLAUDE.md: forbid sub-agents for codebase exploration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,8 @@
+## Working in this codebase
+
+- **Do not use sub-agents (Agent / Task / Explore) for codebase exploration.** Read the actual source files yourself with Read/Grep/Glob. Sub-agent summaries are lossy and have introduced factual errors about this codebase (inventing globals, misreading init order, misattributing ownership). When in doubt, open the file.
+- The authoritative list of process-wide state lives in `src/automat.hh` and `src/root_widget.hh`. Init and teardown order is explicit in `automat::Main()` in `src/automat.cc`.
+
 ## Common Development Commands
 
 If along the way you execute some command, it doesn't work and then you figure out how to make it work, please record that in CLAUDE.md - this way you'll avoid making the same mistakes over and over.


### PR DESCRIPTION
Adds a short note at the top of CLAUDE.md telling future Claude sessions not to dispatch sub-agents (Agent / Task / Explore) for exploring this codebase, and pointing at the authoritative global-state manifests (`src/automat.hh`, `src/root_widget.hh`) and owning scope (`automat::Main()`).

Rationale: sub-agent summaries of this codebase have introduced factual errors (inventing globals, misreading init order, misattributing ownership). Reading the source directly avoids those.

https://claude.ai/code/session_01UYcLHu2uG4Q9GpGi8U1StB