### PR TITLE
libsystemd: only build the targets we install

### DIFF
--- a/run_py/extension_helper.py
+++ b/run_py/extension_helper.py
@@ -110,6 +110,7 @@ class ExtensionHelper:
     self.link_deps = []
     self.ninja_target = 'install'
     self.meson_install_tags = ''
+    self.meson_build_targets = ['all']
 
   def _hook_recipe(self, recipe):
     if self.old_hook_recipe:
@@ -259,10 +260,22 @@ class ExtensionHelper:
           shortcut=f'install {self.name}')
     elif makefile.name == 'meson-info.json':
       import meson
+      # Build and install are two separate ninja invocations so that dependencies
+      # can choose a subset of meson targets to build (via `build_targets`) while
+      # still letting meson handle the install phase. The build step's completion
+      # is signalled by `build_stamp`, which post_success touches after ninja exits 0.
+      build_stamp = build_dir / '.automat.build_stamp'
       recipe.add_step(
-        partial(Popen, meson.ARGS + ['install', '-C', build_dir, '--tags', self.meson_install_tags]),
-        outputs=self.outputs,
+        partial(Popen, [ninja.BIN, '-C', build_dir, *self.meson_build_targets]),
+        outputs=[build_stamp],
         inputs=configure_inputs + [makefile, ninja.BIN],
+        desc=f'Building {self.name}',
+        shortcut=f'build {self.name}',
+        post_success=build_stamp.touch)
+      recipe.add_step(
+        partial(Popen, meson.ARGS + ['install', '-C', build_dir, '--no-rebuild', '--tags', self.meson_install_tags]),
+        outputs=self.outputs,
+        inputs=configure_inputs + [makefile, build_stamp],
         desc=f'Installing {self.name}',
         shortcut=f'install {self.name}')
     else:
@@ -383,11 +396,19 @@ class ExtensionHelper:
     self.configure = 'cmake'
     as_path_list(outputs, self.outputs)
 
-  def ConfigureWithMeson(self, *outputs, install_tags='devel,runtime'):
+  def ConfigureWithMeson(self, *outputs, install_tags='devel,runtime', build_targets=('all',)):
+    '''
+    `build_targets` is the list of meson targets passed to ninja before install.
+    Defaults to `('all',)` which builds everything. Restrict it when the project
+    contains targets we don't consume and that fail to build on some platforms
+    (e.g. systemd's shared libraries linking non-PIC system archives).
+    `install_tags` must cover only files produced by the chosen `build_targets`.
+    '''
     if self.configure:
       raise ValueError(f'{self.name} was already configured')
     self.configure = 'meson'
     self.meson_install_tags = install_tags
+    self.meson_build_targets = list(build_targets)
     as_path_list(outputs, self.outputs)
 
   def ConfigureWithAutotools(self, *outputs):

--- a/run_py/extension_helper.py
+++ b/run_py/extension_helper.py
@@ -260,10 +260,6 @@ class ExtensionHelper:
           shortcut=f'install {self.name}')
     elif makefile.name == 'meson-info.json':
       import meson
-      # Build and install are two separate ninja invocations so that dependencies
-      # can choose a subset of meson targets to build (via `build_targets`) while
-      # still letting meson handle the install phase. The build step's completion
-      # is signalled by `build_stamp`, which post_success touches after ninja exits 0.
       build_stamp = build_dir / '.automat.build_stamp'
       recipe.add_step(
         partial(Popen, [ninja.BIN, '-C', build_dir, *self.meson_build_targets]),
@@ -275,7 +271,7 @@ class ExtensionHelper:
       recipe.add_step(
         partial(Popen, meson.ARGS + ['install', '-C', build_dir, '--no-rebuild', '--tags', self.meson_install_tags]),
         outputs=self.outputs,
-        inputs=configure_inputs + [makefile, build_stamp],
+        inputs=configure_inputs + [makefile, ninja.BIN, build_stamp],
         desc=f'Installing {self.name}',
         shortcut=f'install {self.name}')
     else:

--- a/run_py/extension_helper.py
+++ b/run_py/extension_helper.py
@@ -395,9 +395,6 @@ class ExtensionHelper:
   def ConfigureWithMeson(self, *outputs, install_tags='devel,runtime', build_targets=('all',)):
     '''
     `build_targets` is the list of meson targets passed to ninja before install.
-    Defaults to `('all',)` which builds everything. Restrict it when the project
-    contains targets we don't consume and that fail to build on some platforms
-    (e.g. systemd's shared libraries linking non-PIC system archives).
     `install_tags` must cover only files produced by the chosen `build_targets`.
     '''
     if self.configure:

--- a/run_py/make.py
+++ b/run_py/make.py
@@ -71,6 +71,9 @@ def hexdigest(path):
 
 class Step:
 
+    '''
+    post_success - lambda to execute (synchronously, on the main thread) after job finishes successfully
+    '''
     def __init__(self,
                  build_func,
                  outputs,
@@ -102,10 +105,6 @@ class Step:
         self.id = id
         self.stderr_prettifier = stderr_prettifier
         self.cleanup = cleanup
-        # Optional callback invoked after the step's subprocess exits successfully.
-        # Useful for steps that launch a subprocess (e.g. `ninja`) which does not itself
-        # produce a file the build graph can use as a stamp. The callback runs on the
-        # recipe thread, before downstream steps are unblocked.
         self.post_success = post_success
 
     def __repr__(self):

--- a/run_py/make.py
+++ b/run_py/make.py
@@ -79,6 +79,7 @@ class Step:
                  desc=None,
                  shortcut=None,
                  cleanup=None,
+                 post_success=None,
                  stderr_prettifier=lambda x: x):
         if not desc:
             if hasattr(build_func, '__name__'):
@@ -101,6 +102,11 @@ class Step:
         self.id = id
         self.stderr_prettifier = stderr_prettifier
         self.cleanup = cleanup
+        # Optional callback invoked after the step's subprocess exits successfully.
+        # Useful for steps that launch a subprocess (e.g. `ninja`) which does not itself
+        # produce a file the build graph can use as a stamp. The callback runs on the
+        # recipe thread, before downstream steps are unblocked.
+        self.post_success = post_success
 
     def __repr__(self):
         return f'{self.desc}'
@@ -343,6 +349,8 @@ class Recipe:
                     return False
                 step.builder = None
                 del self.pid_to_step[pid]
+                if step.post_success:
+                    step.post_success()
                 on_step_finished(step)
             else:
                 next = ready_steps.pop()

--- a/run_py/make.py
+++ b/run_py/make.py
@@ -71,9 +71,6 @@ def hexdigest(path):
 
 class Step:
 
-    '''
-    post_success - lambda to execute (synchronously, on the main thread) after job finishes successfully
-    '''
     def __init__(self,
                  build_func,
                  outputs,
@@ -84,6 +81,9 @@ class Step:
                  cleanup=None,
                  post_success=None,
                  stderr_prettifier=lambda x: x):
+        '''
+        post_success - lambda to execute (synchronously, on the main thread) after job finishes successfully
+        '''
         if not desc:
             if hasattr(build_func, '__name__'):
                 desc = f'Running {build_func.__name__}'

--- a/src/libsystemd.py
+++ b/src/libsystemd.py
@@ -106,6 +106,15 @@ if sys.platform == 'linux':
         'ukify': 'disabled',
         'analyze': 'false',
     })
-    hook.ConfigureWithMeson(build.PREFIX / 'lib64' / 'libsystemd.a', install_tags='devel,libsystemd')
+    # We only consume libsystemd.a. Restrict the ninja targets to avoid building
+    # libsystemd-shared-258.so, which on current Debian/Ubuntu links the system
+    # libcrypt.a/libselinux.a — both shipped without -fPIC, which ld then rejects
+    # with R_X86_64_PC32/R_X86_64_TPOFF32 against shared-object relocations.
+    # The `libsystemd` and `devel` targets are alias_target()s in systemd's meson
+    # graph that cover every file in those install tags without pulling in the
+    # shared-library targets.
+    hook.ConfigureWithMeson(build.PREFIX / 'lib64' / 'libsystemd.a',
+                            install_tags='devel,libsystemd',
+                            build_targets=('libsystemd', 'devel'))
     hook.AddLinkArgs('-l:libsystemd.a', '-lcap', '-lm')
     hook.InstallWhenIncluded(r'^systemd/.*')

--- a/src/libsystemd.py
+++ b/src/libsystemd.py
@@ -106,13 +106,6 @@ if sys.platform == 'linux':
         'ukify': 'disabled',
         'analyze': 'false',
     })
-    # We only consume libsystemd.a. Restrict the ninja targets to avoid building
-    # libsystemd-shared-258.so, which on current Debian/Ubuntu links the system
-    # libcrypt.a/libselinux.a — both shipped without -fPIC, which ld then rejects
-    # with R_X86_64_PC32/R_X86_64_TPOFF32 against shared-object relocations.
-    # The `libsystemd` and `devel` targets are alias_target()s in systemd's meson
-    # graph that cover every file in those install tags without pulling in the
-    # shared-library targets.
     hook.ConfigureWithMeson(build.PREFIX / 'lib64' / 'libsystemd.a',
                             install_tags='devel,libsystemd',
                             build_targets=('libsystemd', 'devel'))


### PR DESCRIPTION
Second attempt at the libsystemd fix that landed outside PR #6 because its `build_targets` design needed more work.

## Design

Every meson dep now has **two first-class build-graph steps** instead of one. No `if build_targets:` branch — the default `build_targets=('all',)` preserves previous behaviour for every existing dep.

- **Build step**: `ninja -C <build_dir> <targets>` (previously implicit inside `meson install`).
- **Install step**: `meson install -C <build_dir> --no-rebuild --tags <tags>`.

### Why two steps

`meson install` (no `--no-rebuild`) always runs `ninja all` first. systemd's default ninja target builds `libsystemd-shared-258.so`, which on current Debian/Ubuntu links the system `libcrypt.a` / `libselinux.a` — both shipped without `-fPIC`. ld then rejects `R_X86_64_PC32` / `R_X86_64_TPOFF32` against a shared object. There's no meson option to skip the shared library, so we have to tell ninja to build only the subset we consume.

Since `meson install` can't accept a subset target list, the two phases genuinely need to be separate ninja invocations.

### How the steps communicate

The build step touches `build_dir/.automat.build_stamp` on success; the install step's input includes that stamp. The touch happens via a new `Step.post_success` hook in `run_py/make.py` — a three-line addition that invokes a user-supplied callback after a subprocess exits 0. This avoids both blocking Python synchronously during `ninja` (which would stall parallel build pipelines) and coupling to the `HASH_DIR/shortcut` internal file that make.py already writes.

### libsystemd target selection

`build_targets=('libsystemd', 'devel')` — the two `alias_target()`s in systemd's meson graph that cover every file under the `libsystemd` and `devel` install tags without pulling in the shared library.

## Verified

- `install libsystemd` from clean: 45s, 5 steps, "Building libsystemd" and "Installing libsystemd" show as separate build-graph events. `libsystemd.a` (4.7MB) produced.
- `install libsystemd` no-op: 0.002s.
- `install PipeWire` from clean with default `build_targets=('all',)`: 28s — existing deps unchanged.
- PipeWire no-op: 0.002s.

https://claude.ai/code/session_01UYcLHu2uG4Q9GpGi8U1StB