### PR TITLE
RootWidget::Tick: update only this window's pointers

### DIFF
--- a/src/root_widget.cc
+++ b/src/root_widget.cc
@@ -375,10 +375,8 @@ animation::Phase RootWidget::Tick(time::Timer& timer) {
   }
 
   if (phase == animation::Animating) {
-    for (auto& each_window : root_widgets) {
-      for (auto& each_pointer : each_window->pointers) {
-        each_pointer->UpdatePath();
-      }
+    for (auto& each_pointer : pointers) {
+      each_pointer->UpdatePath();
     }
   }
 


### PR DESCRIPTION
`RootWidget::Tick` iterated `root_widgets` and called `UpdatePath()` on every pointer in every window, so with N windows each frame's work was N² instead of N. Fix: iterate only this window's own `pointers` — each window ticks itself.

Harmless today (there's only one `RootWidget`), but wrong once multi-window support lands. Isolating it as prep.

https://claude.ai/code/session_01UYcLHu2uG4Q9GpGi8U1StB